### PR TITLE
Added more code to check params and url

### DIFF
--- a/fmgr_generic.py
+++ b/fmgr_generic.py
@@ -154,6 +154,11 @@ def main():
     if method not in ['get', 'add', 'set', 'update', 'delete', 'move', 'clone', 'exec']:
         module.fail_json(msg='method:%s not supported' % (method))
 
+    if not isinstance(params, list):
+        module.fail_json(msg='parameter:params must be an array')
+    for param_block in params:
+        if 'url' not in param_block:
+            module.fail_json(msg='url must be specified in params')
     try:
         response = connection.send_request(method, params)
         fmgr.govern_response(module=module, results=response, msg='Operation Finished',


### PR DESCRIPTION
This patch checks parameters and url.

## `params` must be an array. 
otherwise, it reports errors like:
```
fatal: [fortimanager01]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "json": "{\n \"method\":\"set\",\n \"params\": \n  {\n       \"url\":\"/dvmdb/adom/root/script\",\n       \"data\":[\n          {\n             \"name\": \"user_script2\",\n             \"type\": \"cli\",\n             \"desc\": \"The script is created by ansible\",\n             \"content\": \"the script content to be executed\"\n          }\n        ]\n   }\n \n}\n",
            "method": null,
            "params": null
        }
    },
    "msg": "parameter:params must be an array"
}

PLAY RECAP ***************************************************************************************************************************************************************************************************************
fortimanager01             : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```
## `url` must be in a parameter block. 
otherwise, it reports errors like:
```
fatal: [fortimanager01]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "json": "{\n \"method\":\"set\",\n \"params\":[ \n  {\n       \"data\":[\n          {\n             \"name\": \"user_script2\",\n             \"type\": \"cli\",\n             \"desc\": \"The script is created by ansible\",\n             \"content\": \"the script content to be executed\"\n          }\n        ]\n   }\n ]\n}\n",
            "method": null,
            "params": null
        }
    },
    "msg": "url must be specified in params"
}

PLAY RECAP ***************************************************************************************************************************************************************************************************************
fortimanager01             : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```
