### PR TITLE
Fixed the error message when testing whether patch is already applied

### DIFF
--- a/patch_ansible
+++ b/patch_ansible
@@ -7,8 +7,8 @@ fmgr_plugin_file=$ansible_dir"/plugins/httpapi/fortimanager.py"
 #$2: the patch file
 patch_file() {
     echo "patching "$1
-    if ! patch -R --dry-run -s -f  $1 < $2; then
-        patch $1 < $2 > /dev/zero;
+    if ! patch -R --dry-run -s -f  $1 < $2 > /dev/null; then
+        patch $1 < $2 > /dev/null;
     fi
 }
 


### PR DESCRIPTION
when testing whether the patch is already applied, it reports error message:
```
1 out of 1 hunk FAILED
```

remove the error message since it's not user error.

```
#ansible-playbook --version
ansible-playbook 2.10.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /root/DEV/ansible-fortimanager-generic/ansible2.9.0.new/lib/python3.6/site-packages/ansible-2.10.0.dev0-py3.6.egg/ansible
  executable location = /root/DEV/ansible-fortimanager-generic/ansible2.9.0.new/bin/ansible-playbook
  python version = 3.6.9 (default, Nov  7 2019, 10:44:02) [GCC 8.3.0]

#source patch_ansible
do you want to patch for 2.10.0.dev0 ? [yes/no]yes
patching /root/DEV/ansible-fortimanager-generic/ansible2.9.0.new/lib/python3.6/site-packages/ansible-2.10.0.dev0-py3.6.egg/ansible/plugins/httpapi/fortimanager.py
```

@frankshen01 