### PR TITLE
fixed the compliance error: string equality operator not recognized

### DIFF
--- a/patch_ansible
+++ b/patch_ansible
@@ -17,7 +17,7 @@ known_unpatched_list="2.9.0  2.9.1  2.9.2  2.9.3  2.9.4  2.9.5"
 
 found=false
 for v in $known_unpatched_list; do
-    if [ "$v" == "$ansible_version" ]; then
+    if [ "$v" = "$ansible_version" ]; then
         found=true
         break
     fi
@@ -29,16 +29,16 @@ is_ansible_28x=$?
 ask_for_patch() {
     printf "do you want to patch for $ansible_version ? [yes/no]"
     read option
-    if [ "$option" == "yes" ]; then
+    if [ "$option" = "yes" ]; then
         patch_file $fmgr_plugin_file patches/ansible.2.9.x.patch
     fi
 }
 
 patch_file $fmgr_module_util_file patches/fortimanager_plugin.patch
 
-if [ $found == true ]; then
+if [ $found = true ]; then
     patch_file $fmgr_plugin_file patches/ansible.2.9.x.patch
-elif [ $is_ansible_28x == 0 ]; then
+elif [ $is_ansible_28x = 0 ]; then
     echo "No need to patch ansible "$ansible_version" fortimanager plugin"
 else
     ask_for_patch


### PR DESCRIPTION
when running the script by `./patch_ansible` (in the manual, we run the patch script by `source patch_ansible`), the string operator == is not recognized. 
```
#./patch_ansible
./patch_ansible: 20: [: 2.9.0: unexpected operator
./patch_ansible: 20: [: 2.9.1: unexpected operator
./patch_ansible: 20: [: 2.9.2: unexpected operator
./patch_ansible: 20: [: 2.9.3: unexpected operator
./patch_ansible: 20: [: 2.9.4: unexpected operator
./patch_ansible: 20: [: 2.9.5: unexpected operator
patching /usr/local/lib/python3.6/dist-packages/ansible-2.10.0.dev0-py3.6.egg/ansible/module_utils/network/fortimanager/fortimanager.py
./patch_ansible: 39: [: false: unexpected operator
./patch_ansible: 41: [: 1: unexpected operator
do you want to patch for 2.10.0.dev0 ? [yes/no]yes
./patch_ansible: 32: [: yes: unexpected operator
```

with the fix:
```
#./patch_ansible
patching /usr/local/lib/python3.6/dist-packages/ansible-2.10.0.dev0-py3.6.egg/ansible/module_utils/network/fortimanager/fortimanager.py
do you want to patch for 2.10.0.dev0 ? [yes/no]yes
patching /usr/local/lib/python3.6/dist-packages/ansible-2.10.0.dev0-py3.6.egg/ansible/plugins/httpapi/fortimanager.py
```

cc @frankshen01 