### PR TITLE
fixed https://github.com/fortinet/ansible-fortimanager-generic/issues/10

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,6 @@ One example is `/dvm/cmd/add/device`, 0 is returned if the device is not present
                   flags:
                     - none
       register: provision
-      ignore_errors: yes
-
-    - name: Detecting the Provisioning task.
-      fail:
-        msg: "the Provisioning task fail"
       failed_when: provision.rc != 0 and provision.rc != -20010
 ```
 

--- a/example/example_add_device.yml
+++ b/example/example_add_device.yml
@@ -52,10 +52,5 @@
       until: taskinfo.ansible_module_results.percent == 100
       retries: 60
       delay: 5
-
-
-    - name: Detect errors in previous task
-      fail:
-        msg: 'the device is not installed correctly, see more in log'
       failed_when:
         - taskinfo.ansible_module_results.state == 'error' and  'devsnexist' not in taskinfo.ansible_module_results.line[0].detail

--- a/example/example_delete_device.yml
+++ b/example/example_delete_device.yml
@@ -34,12 +34,6 @@
       until: taskinfo.ansible_module_results.percent == 100
       retries: 60
       delay: 5
-
-
-    - name: Detect errors in previous task
-      when: "'taskid' in uninstalling_task.ansible_module_results"
-      fail:
-        msg: 'the device is not installed correctly, see more in log'
       failed_when:
         - taskinfo.ansible_module_results.num_err != 0
         - taskinfo.ansible_module_results.state == 'error'

--- a/example/example_execute_script.yml
+++ b/example/example_execute_script.yml
@@ -51,10 +51,6 @@
       until: taskinfo.ansible_module_results.percent == 100
       retries: 60
       delay: 5
-
-    - name:
-      fail:
-        msg: "see task history: {{ executing_task.ansible_module_results.task }}"
       failed_when:
         - taskinfo.ansible_module_results.state == 'error'
         - taskinfo.ansible_module_results.num_err != 0

--- a/example/example_install_policy.yml
+++ b/example/example_install_policy.yml
@@ -72,11 +72,6 @@
                 service: "{{ service_name }}"
                 schedule: "{{ schedule_name }}"
       register: policyinfo
-      ignore_errors: true
-
-    - name: detect errorr in case policy is duplicated
-      fail:
-        msg: "more info by :-vvvv"
       failed_when: policyinfo.rc != 0 and policyinfo.rc != -9998
 
 
@@ -102,10 +97,6 @@
       until: taskinfo.ansible_module_results.percent == 100
       retries: 60
       delay: 5
-
-    - name: Detect errors in the final task
-      fail:
-        msg: "see more by : -vvv"
       failed_when:
         - taskinfo.ansible_module_results.state == 'error'
 

--- a/patches/fortimanager_plugin.patch
+++ b/patches/fortimanager_plugin.patch
@@ -1,8 +1,12 @@
-259c259
+252a253
+>                 # XXX: remove skipped because that will affect `failed_when` behavior
+258,259c259,260
+<                     module.exit_json(msg=msg, failed=failed, changed=changed, unreachable=unreachable, skipped=skipped,
 <                                      results=results[1], ansible_facts=ansible_facts, rc=results[0],
 ---
+>                     module.exit_json(msg=msg, failed=failed, changed=changed, unreachable=unreachable,
 >                                      ansible_module_results=results[1], ansible_facts=ansible_facts, rc=results[0],
-267c267
+267c268
 <                                      skipped=skipped, results=results[1], ansible_facts=ansible_facts, rc=results[0],
 ---
->                                      skipped=skipped, ansible_module_results=results[1], ansible_facts=ansible_facts, rc=results[0],
+>                                      ansible_module_results=results[1], ansible_facts=ansible_facts, rc=results[0],


### PR DESCRIPTION
```
- name: Create a script on fortimanager.
  hosts: fortimanager01
  gather_facts: no
  connection: httpapi
  vars:
    ansible_httpapi_use_ssl: True
    ansible_httpapi_validate_certs: False
    ansible_httpapi_port: 443
    script_name: demoscript1
    script_adom: root
    script_device_name: "FGVM04TM19006963"
    script_device_vdom: "root"
  tasks:
    - name: Create A Script on FortiManager
      fmgr_generic:
         method: set
         params:
            - url: "/dvmdb/adom/{{ script_adom }}/script"
              data:
                - name: "{{ script_name }}"
                  type: "cli"
                  desc: "The script is created by ansible"
                  content: |
                            config firewall policy
                                edit 1
                                    set name foopolicy
                                    set srcintf "any"
                                next
                            end
      register: info
      failed_when: info.rc == 0
```

then run the playbook, the task is supposed to fail.
```
PLAY RECAP **************************************************************************************************************************************************************************************************************************
fortimanager01             : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```