### PR TITLE
support rc_succeeded and rc_failed statements

### DIFF
--- a/fmgr_generic.py
+++ b/fmgr_generic.py
@@ -113,6 +113,14 @@ import json
 def main():
 
     module_arg_spec = {
+        'rc_succeeded': {
+            'required': False,
+            'type': 'list'
+        },
+        'rc_failed': {
+            'required': False,
+            'type': 'list'
+        },
         'method': {
             'type': 'str',
             'required': False
@@ -162,7 +170,8 @@ def main():
     try:
         response = connection.send_request(method, params)
         fmgr.govern_response(module=module, results=response, msg='Operation Finished',
-                             ansible_facts=fmgr.construct_ansible_facts(response, module.params, module.params))
+                             ansible_facts=fmgr.construct_ansible_facts(response, module.params, module.params),
+                             changed_if_success=True, stop_on_success=True)
     except Exception as e:
         module.fail_json(msg='error sending request: %s' % (e))
 

--- a/patch_ansible
+++ b/patch_ansible
@@ -13,7 +13,7 @@ patch_file() {
     fi
 }
 
-known_unpatched_list="2.9.0  2.9.1  2.9.2  2.9.3  2.9.4  2.9.5"
+known_unpatched_list="2.9.0  2.9.1  2.9.2  2.9.3  2.9.4  2.9.5  2.9.6  2.9.7  2.9.8"
 
 found=false
 for v in $known_unpatched_list; do

--- a/patches/fortimanager_plugin.patch
+++ b/patches/fortimanager_plugin.patch
@@ -1,12 +1,37 @@
-252a253
+145a146,148
+>         # Override the good codes if users specify some
+>         if module.params['rc_succeeded'] is not None:
+>             rc_data["good_codes"] = module.params['rc_succeeded']
+174c177
+<                                     good_codes=rc_data.get("good_codes", (0,)),
+---
+>                                     good_codes=rc_data.get("good_codes", [0]),
+233c236,237
+<         if not failed and not success:
+---
+>         ansible_rc = 0
+>         if len(good_codes) > 0 or module.params['rc_failed'] and len(module.params['rc_failed']) > 0:
+234a239
+>                 ansible_rc = results[0]
+238a244,250
+>                     ansible_rc = 0
+>                 # Continue to identify failure codes. that's to say, failure codes has higher priority
+>                 if module.params['rc_failed'] and results[0] in module.params['rc_failed']:
+>                     success = False
+>                     failed = True
+>                     ansible_rc = results[0]
+>                     msg = 'Ansible result overridden'
+252a265
 >                 # XXX: remove skipped because that will affect `failed_when` behavior
-258,259c259,260
+258,259c271,272
 <                     module.exit_json(msg=msg, failed=failed, changed=changed, unreachable=unreachable, skipped=skipped,
 <                                      results=results[1], ansible_facts=ansible_facts, rc=results[0],
 ---
 >                     module.exit_json(msg=msg, failed=failed, changed=changed, unreachable=unreachable,
->                                      ansible_module_results=results[1], ansible_facts=ansible_facts, rc=results[0],
-267c268
+>                                      ansible_module_results=results[1], ansible_facts=ansible_facts, rc=ansible_rc,
+264d276
+<                     success = False
+267c279
 <                                      skipped=skipped, results=results[1], ansible_facts=ansible_facts, rc=results[0],
 ---
->                                      ansible_module_results=results[1], ansible_facts=ansible_facts, rc=results[0],
+>                                      ansible_module_results=results[1], ansible_facts=ansible_facts, rc=ansible_rc,


### PR DESCRIPTION
```
- name: Create a script on fortimanager.
  hosts: fortimanager01
  gather_facts: no
  connection: httpapi
  vars:
    ansible_httpapi_use_ssl: True
    ansible_httpapi_validate_certs: False
    ansible_httpapi_port: 443
    script_name: demoscript1
    script_adom: root
    script_device_name: "FGVM04TM19006963"
    script_device_vdom: "root"
  tasks:
    - name: Create A Script on FortiManager
      fmgr_generic:
         method: set
         params:
            - url: "/dvmdb/adom/{{ script_adom }}/script"
              data:
                - name: "{{ script_name }}"
                  type: "cli"
                  desc: "The script is created by ansible"
                  content: |
                            config firewall policy
                                edit 1
                                    set name foopolicy
                                    set srcintf "any"
                                next
                            end
         rc_succeeded:
            - 0
            - -20
         rc_failed:
            - 0
      register: task
      failed_when:
        - task.rc != 0

    - name: Execute the script on the device
      fmgr_generic:
        method: exec
        params:
            - url: "/dvmdb/adom/{{ script_adom }}/script/execute"
              data:
                script: "{{ script_name }}"
                adom: "{{ script_adom }}"
                scope:
                    - name: "{{ script_device_name }}"
                      vdom: "{{ script_device_vdom }}"
        rc_succeeded:
            - -8
      register: executing_task

```

all two tasks succeed even though second actually didn't, but it is overridden by `rc_succeeded`

```
$ansible-playbook -i hosts  example_execute_script.yml

PLAY [Create a script on fortimanager.] **************************************************************************************************************************************************************************************************

TASK [Create A Script on FortiManager] ***************************************************************************************************************************************************************************************************

changed: [fortimanager01]

TASK [Execute the script on the device] **************************************************************************************************************************************************************************************************
changed: [fortimanager01]

TASK [Poll and wait for task to complete] ************************************************************************************************************************************************************************************************
skipping: [fortimanager01]

PLAY RECAP *******************************************************************************************************************************************************************************************************************************
fortimanager01             : ok=2    changed=2    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0

```